### PR TITLE
Expose Controller.isDisposed to subclasses; fix ActivityTracker write-after-dispose (v2.1.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 2.1.0
+
+### Added
+
+- `Controller.isDisposed` — protected getter exposing the controller's
+  disposal state, so subclasses can guard plain signal writes that follow an
+  `await` (`if (isDisposed) return;`) without re-implementing their own
+  `_disposed` flag. `runInto` and `watch` already guard their own writes;
+  this covers state that doesn't fit the `AsyncState` shape ([#6](https://github.com/f0x-it-llc/clean_signals/issues/6)).
+
+### Fixed
+
+- `ActivityTracker.track` no longer writes to its disposed counter signal
+  when a tracked operation is still in flight during `dispose()` — an
+  in-flight `run(...)` used to throw `SignalsWriteAfterDisposeError` from
+  its `finally` block when the controller was disposed mid-operation.
+
 ## 2.0.0
 
 **Renamed from `base_core` to `clean_signals`** (the original name was taken

--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ What the base class provides:
 | `failures` | Broadcast `Stream<Failure>` of every unhandled failure (after retries). |
 | `autoEffect(fn)` | A signals `effect` cleaned up on dispose. |
 | `onDispose(fn)` | Register any cleanup; run in reverse order by `dispose()`. |
+| `isDisposed` | `true` once `dispose()` has run. Guard writes to plain signals that follow an `await` (`if (isDisposed) return;`) — `runInto`/`watch` guard their own writes already. |
 
 ### RetryPolicy
 

--- a/example/lib/features/team/presentation/controllers/member_detail_controller.dart
+++ b/example/lib/features/team/presentation/controllers/member_detail_controller.dart
@@ -26,6 +26,10 @@ class MemberDetailController extends Controller {
 
   /// Renames the member. Returns true on success so the UI can close the
   /// edit sheet; failures (validation, network) surface on [failures].
+  ///
+  /// This controller is screen-scoped (factory-registered, disposed by the
+  /// page), so it can be disposed while the rename is in flight — every
+  /// signal write after the `await` is guarded with [isDisposed].
   Future<bool> rename(String name) async {
     saving.value = true;
     try {
@@ -36,13 +40,13 @@ class MemberDetailController extends Controller {
       );
       return result.fold(
         onSuccess: (updated) {
-          member.value = AsyncState.data(updated);
+          if (!isDisposed) member.value = AsyncState.data(updated);
           return true;
         },
         onFailure: (_) => false,
       );
     } finally {
-      saving.value = false;
+      if (!isDisposed) saving.value = false;
     }
   }
 }

--- a/lib/src/activity.dart
+++ b/lib/src/activity.dart
@@ -9,6 +9,7 @@ class ActivityTracker {
   ActivityTracker();
 
   final Signal<int> _count = signal(0);
+  bool _disposed = false;
 
   /// Number of operations currently in flight.
   late final ReadonlySignal<int> pending = _count.readonly();
@@ -17,16 +18,22 @@ class ActivityTracker {
   late final ReadonlySignal<bool> isLoading = computed(() => _count.value > 0);
 
   /// Runs [operation], keeping [isLoading] `true` for its duration.
+  ///
+  /// Counter updates are skipped once [dispose] has run, so an operation
+  /// still in flight when the tracker is torn down completes without
+  /// writing to a disposed signal.
   Future<T> track<T>(Future<T> Function() operation) async {
-    _count.value++;
+    if (!_disposed) _count.value++;
     try {
       return await operation();
     } finally {
-      _count.value--;
+      if (!_disposed) _count.value--;
     }
   }
 
   void dispose() {
+    if (_disposed) return;
+    _disposed = true;
     isLoading.dispose();
     _count.dispose();
   }

--- a/lib/src/controller.dart
+++ b/lib/src/controller.dart
@@ -21,7 +21,8 @@ import 'usecase.dart';
 ///   logging, analytics),
 /// - per-call [RetryPolicy] retries,
 /// - lifecycle cleanup: everything registered with [onDispose], created with
-///   [autoEffect], or subscribed with [watch] is torn down by [dispose].
+///   [autoEffect], or subscribed with [watch] is torn down by [dispose];
+///   [isDisposed] lets subclasses guard their own post-`await` signal writes.
 ///
 /// ```dart
 /// class UsersController extends Controller {
@@ -56,6 +57,23 @@ abstract class Controller {
   /// are exhausted). Subscribe once near the UI root of the feature to show
   /// snackbars or report errors.
   Stream<Failure> get failures => _failures.stream;
+
+  /// Whether [dispose] has run.
+  ///
+  /// [runInto] and [watch] already skip their own writes after disposal, but
+  /// a controller often owns plain signals it updates after an `await`. If
+  /// the controller is disposed while that operation is in flight (e.g. the
+  /// screen was popped), the write would throw. Guard such sites:
+  ///
+  /// ```dart
+  /// Future<void> loadServers() async {
+  ///   final result = await run(_getServers, noParams);
+  ///   if (isDisposed) return;
+  ///   servers.value = result.getOrElse((_) => const []);
+  /// }
+  /// ```
+  @protected
+  bool get isDisposed => _disposed;
 
   /// Registers [cleanup] to run when the controller is disposed.
   /// Cleanups run in reverse registration order.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   A lightweight use-case and controller framework for signals-based Flutter
   and Dart applications. Typed results, sealed failures, ref-counted activity
   tracking and declarative retries — without rxdart or dartz.
-version: 2.0.0
+version: 2.1.0
 homepage: https://github.com/f0x-it-llc/clean_signals
 repository: https://github.com/f0x-it-llc/clean_signals
 topics:

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -90,6 +90,10 @@ lib/features/<feature>/
   Never implement retry loops by hand.
 - Register every owned signal and subscription for cleanup:
   `onDispose(signal.dispose)`, `autoEffect(...)`, `watch(...)` (auto-cancels).
+- A plain signal write that follows an `await` must be guarded with
+  `if (isDisposed) return;` — a screen-scoped controller can be disposed
+  while the operation is in flight, and an unguarded write then throws.
+  (`runInto`/`watch` guard their own writes; this is only for raw writes.)
 - Controllers never import Flutter and never touch `BuildContext`.
   Navigation and snackbars belong to pages; controllers return values/expose
   signals the page reacts to.

--- a/test/activity_test.dart
+++ b/test/activity_test.dart
@@ -47,6 +47,21 @@ void main() {
       expect(await tracker.track(() async => 7), 7);
       tracker.dispose();
     });
+
+    test('an operation in flight during dispose completes without writing '
+        'to the disposed counter', () async {
+      final tracker = ActivityTracker();
+      final gate = Completer<void>();
+
+      final pending = tracker.track(() async {
+        await gate.future;
+        return 7;
+      });
+
+      tracker.dispose();
+      gate.complete();
+      expect(await pending, 7);
+    });
   });
 
   group('RetryPolicy', () {

--- a/test/controller_test.dart
+++ b/test/controller_test.dart
@@ -77,6 +77,8 @@ class TestController extends Controller {
       watch(useCase, params, onData: onData);
 
   void addCleanup(void Function() fn) => onDispose(fn);
+
+  bool get disposed => isDisposed;
 }
 
 void main() {
@@ -282,6 +284,33 @@ void main() {
       controller.dispose();
       controller.dispose();
       expect(order, ['second', 'first']);
+    });
+
+    test('isDisposed reflects lifecycle', () {
+      final controller = TestController();
+      expect(controller.disposed, isFalse);
+
+      controller.dispose();
+      expect(controller.disposed, isTrue);
+    });
+
+    test('isDisposed guards a raw signal write after an await', () async {
+      final controller = TestController();
+      final gate = Completer<void>();
+      final value = signal<int?>(null);
+
+      Future<void> load() async {
+        final result = await controller.exec(SlowUseCase(gate), noParams);
+        if (controller.disposed) return;
+        value.value = result.getOrElse((_) => 0);
+      }
+
+      final pending = load();
+      controller.dispose();
+      gate.complete();
+      await pending;
+
+      expect(value.value, isNull, reason: 'write skipped after dispose');
     });
   });
 }


### PR DESCRIPTION
Fixes #6.

## What

- **`Controller.isDisposed`** — new `@protected` getter exposing the disposal state the base class already tracks, so subclasses can guard plain signal writes that follow an `await` (`if (isDisposed) return;`) instead of hand-rolling a `_disposed` flag. Doc comments include the guard pattern.
- **`ActivityTracker` write-after-dispose fix** — writing the test for the guard pattern exposed the same hazard inside the library: `track()`'s `finally` decremented the counter signal after `dispose()`, so any `run(...)` still in flight when a controller was disposed threw `SignalsWriteAfterDisposeError` — even code using the new guard would have crashed through this path. The tracker now skips counter updates once disposed.

## Also in this PR (per repo API-change rules)

- Tests: `isDisposed` lifecycle + await-then-write guard scenario; `ActivityTracker` in-flight-during-dispose.
- README: `isDisposed` row in the Controller members table.
- CHANGELOG 2.1.0 (Added + Fixed); `pubspec.yaml` 2.0.0 → 2.1.0 (additive, minor).
- `templates/AGENTS.md`: presentation rule requiring the guard on raw post-`await` writes.
- `example/`: `MemberDetailController.rename` (factory-scoped — the exact crash path from the issue) now demonstrates the guard. `SessionController` untouched: app-scoped singleton, never disposed.

## Verification

`dart analyze` + `dart test` (34 tests) and `cd example && flutter analyze && flutter test` all pass with zero issues.